### PR TITLE
EJBCA connection with private CA is not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ through Microsoft Intune and certificate enrollment through EJBCA.
     - **SSL server certificate** - Used by Tomcat connector to secure communication from mobile devices. Should be issued as a Java Keystore (JKS).
     - **SCEP Receiver certificate** - Used by Intune EJBCA Connector to secure SCEP messages from mobile devices. Should be issued as a Java Keystore (JKS) and will be returned to mobile devices through the SCEP call `GetCACerts`.
     - **EJBCA Admin certificate** - Used by Intune EJBCA Connector to authenticate to EJBCA Web service. Should be issued as a Java Keystore (JKS) and given required administrator permissions.
+    - **EJBCA SSL certificate** - Used by Intune EJBCA Connector to communicate to EJBCA Web service. Should be issued as a Java Keystore (JKS). It needs only root and intermediate certificate, do not include the EJBCA server certificate ane keys (Optional)
 
 3.  Prepare a Tomcat application server that is going to host the
     web application. It is strongly recommended to setup a secure HTTPS
@@ -103,13 +104,16 @@ Values for `appId` and `appKey` should be specified as noted in step 1 in _Setup
 ### EJBCA configuration
 Section (**ejbca:**) containing configuration needed in order to connect to EJBCA.
 
-| Key              | Description
-| ---------------- | -----------
-| serviceName      | Arbitrary name and version of EJBCA service _(ex. EJBCA 6.3.1.1)_.
-| serviceUrl       | EJBCA web service endpoint URL.
-| keystorePath     | Path to java key store containing administrator certificate to use when authenticating to EJBCA web service.
-| keystorePassword | Password that protects the keystore and the private key.
-| sslAlgorithm     | SSL Algorithm to use when connecting to EJBCA *(Optional - default is TLSv1.2)*
+| Key                | Description
+| ------------------ | -----------
+| serviceName        | Arbitrary name and version of EJBCA service _(ex. EJBCA 6.3.1.1)_.
+| serviceUrl         | EJBCA web service endpoint URL.
+| keystorePath       | Path to java key store containing administrator certificate to use when authenticating to EJBCA web service.
+| keystorePassword   | Password that protects the keystore and the private key.
+| truststorePath     | Path to java key store containing root and intermediate certificate to use when communicate to EJBCA web service (Optional)
+| truststorePassword | Password that protects the truststore (Optional - required to use truststore)
+| sslAlgorithm       | SSL Algorithm to use when connecting to EJBCA *(Optional - default is TLSv1.2)*
+
 ### SCEP configuration
 Section (**scep:**) containing configuration needed for the SCEP service.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ through Microsoft Intune and certificate enrollment through EJBCA.
     - **SSL server certificate** - Used by Tomcat connector to secure communication from mobile devices. Should be issued as a Java Keystore (JKS).
     - **SCEP Receiver certificate** - Used by Intune EJBCA Connector to secure SCEP messages from mobile devices. Should be issued as a Java Keystore (JKS) and will be returned to mobile devices through the SCEP call `GetCACerts`.
     - **EJBCA Admin certificate** - Used by Intune EJBCA Connector to authenticate to EJBCA Web service. Should be issued as a Java Keystore (JKS) and given required administrator permissions.
-    - **EJBCA SSL certificate** - Used by Intune EJBCA Connector to communicate to EJBCA Web service. Should be issued as a Java Keystore (JKS). It needs only root and intermediate certificate, do not include the EJBCA server certificate ane keys (Optional)
+    - **EJBCA SSL truststore** - Used by Intune EJBCA Connector to communicate to EJBCA Web service. Should be issued as a Java Keystore (JKS). It needs only root and intermediate certificate, do not include the EJBCA server certificate or keys (Optional)
 
 3.  Prepare a Tomcat application server that is going to host the
     web application. It is strongly recommended to setup a secure HTTPS

--- a/grails-app/services/org/certificateservices/intune/ejbcaconnector/EjbcaService.groovy
+++ b/grails-app/services/org/certificateservices/intune/ejbcaconnector/EjbcaService.groovy
@@ -32,6 +32,7 @@ import org.ejbca.core.protocol.ws.*
 
 import javax.annotation.PostConstruct
 import javax.net.ssl.KeyManagerFactory
+import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.SSLContext
 import javax.xml.namespace.QName
 import javax.xml.ws.BindingProvider
@@ -124,11 +125,18 @@ class EjbcaService {
         log.debug "Creating SSL Context for EJBCA WS connection (Keystore: ${keystorePath}, Algorithm: ${algorithm}"
 
         SSLContext context = SSLContext.getInstance(algorithm)
+
         KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm())
         KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType())
         keyStore.load(new FileInputStream(keystorePath), keystorePassword.toCharArray())
         keyManagerFactory.init(keyStore, keystorePassword.toCharArray())
-        context.init(keyManagerFactory.getKeyManagers(), null, null)
+
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm())
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType())
+        trustStore.load(new FileInputStream(keystorePath), keystorePassword.toCharArray())
+        trustManagerFactory.init(trustStore)
+
+        context.init(keyManagerFactory.getKeyManagers(), trustManagerFactory.getTrustManagers(), null)
 
         return context
     }


### PR DESCRIPTION
EJBCA connection with private CA, like ManagementCA generated by EJBCA, is not working.

My environment is below:
- OpenJDK 1.8.0_212
- Apache Tomcat 8.5.41
- Docker

It seems Apache CXF is not worked well with KeyManager and no TrustManager. Add trust certificate to the keychain, and pass it with TrustManager, it worked.

I need to know:
- Is it depend only on my environment?
- Is it right to pass another keychain for truststure?
  - If it is, I can write more patch.

Please give me feedback.